### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "examples/rooster-ui/rooster-dao-ui"]
 	path = examples/rooster-ui/rooster-dao-ui
-	url = git@github.com:RoosterDao/rooster-dao-ui.git
+	url = https://github.com/RoosterDao/rooster-dao-ui.git
 	branch = rooster-dao-ui-prototype
 [submodule "examples/rooster-ui/contracts-ui-with-nft-viewer"]
 	path = examples/rooster-ui/contracts-ui-with-nft-viewer
-	url = git@github.com:RoosterDao/contracts-ui-with-nft-viewer.git
+	url = https://github.com/RoosterDao/contracts-ui-with-nft-viewer.git


### PR DESCRIPTION
  Fix the following error when getting `dapps_staking_extension` as a dependency
   
    Caused by:
      failed to load source for dependency `dapps_staking_extension`   
    Caused by:
      Unable to update https://github.com/AstarNetwork/chain-extension-contracts
    Caused by:
      failed to update submodule `examples/rooster-ui/contracts-ui-with-nft-viewer`
    Caused by:
      failed to fetch submodule `examples/rooster-ui/contracts-ui-with-nft-viewer` from git@github.com:RoosterDao/contracts-ui-with-nft-viewer.git   
    Caused by:
      failed to authenticate when downloading repository
   